### PR TITLE
Feature: add Default Amount config option

### DIFF
--- a/Dagobert/AutoPinch.cs
+++ b/Dagobert/AutoPinch.cs
@@ -484,32 +484,35 @@ namespace Dagobert
           var ui = &retainerSell->AtkUnitBase;
           var itemName = retainerSell->ItemName->NodeText.ToString();
           _oldPrice = retainerSell->AskingPrice->Value;
-          if (_newPrice.HasValue && _newPrice > 0)
+          if (!_newPrice.HasValue || !(_newPrice > 0))
           {
-            var cutPercentage = ((float)_newPrice.Value - _oldPrice.Value) / _oldPrice.Value * 100f;
-            if (cutPercentage >= -Plugin.Configuration.MaxUndercutPercentage)
+            if (Plugin.Configuration.DefaultAmount == 0)
             {
-              Svc.Log.Debug($"Setting new price");
-              _cachedPrices.TryAdd(itemName, _newPrice);
-              retainerSell->AskingPrice->SetValue(_newPrice.Value);
-              Communicator.PrintPriceUpdate(itemName, _oldPrice.Value, _newPrice.Value, cutPercentage);
+              Svc.Log.Warning("SetNewPrice: No price to set");
+              Communicator.PrintNoPriceToSetError(itemName);
+              ECommons.Automation.Callback.Fire(&retainerSell->AtkUnitBase, true, 1); // cancel
+              ui->Close(true);
+              return true;
             }
-            else
-              Communicator.PrintAboveMaxCutError(itemName);
-
-            ECommons.Automation.Callback.Fire(&retainerSell->AtkUnitBase, true, 0); // confirm
-            ui->Close(true);
-
-            return true;
+	    Svc.Log.Warning("SetNewPrice: Using default amount");
+            _newPrice = Plugin.Configuration.DefaultAmount;
+	    Communicator.PrintUsingDefaultAmountWarning(itemName, _newPrice.Value);
+          }
+          var cutPercentage = ((float)_newPrice.Value - _oldPrice.Value) / _oldPrice.Value * 100f;
+          if (cutPercentage >= -Plugin.Configuration.MaxUndercutPercentage)
+          {
+            Svc.Log.Debug($"Setting new price");
+            _cachedPrices.TryAdd(itemName, _newPrice);
+            retainerSell->AskingPrice->SetValue(_newPrice.Value);
+            Communicator.PrintPriceUpdate(itemName, _oldPrice.Value, _newPrice.Value, cutPercentage);
           }
           else
-          {
-            Svc.Log.Warning("SetNewPrice: No price to set");
-            Communicator.PrintNoPriceToSetError(itemName);
-            ECommons.Automation.Callback.Fire(&retainerSell->AtkUnitBase, true, 1); // cancel
-            ui->Close(true);
-            return true;
-          }
+            Communicator.PrintAboveMaxCutError(itemName);
+
+          ECommons.Automation.Callback.Fire(&retainerSell->AtkUnitBase, true, 0); // confirm
+          ui->Close(true);
+
+          return true;
         }
         else
           return false;

--- a/Dagobert/Communicator.cs
+++ b/Dagobert/Communicator.cs
@@ -151,6 +151,25 @@ public static class Communicator
       Svc.Chat.PrintError($"{itemName}: No price to set, please set price manually");
   }
 
+  public static void PrintUsingDefaultAmountWarning(string itemName, int amount)
+  {
+    if (!Plugin.Configuration.ShowErrorsInChat)
+      return;
+
+    var itemPayload = RawItemNameToItemPayload(itemName);
+    if (itemPayload != null)
+    {
+      var seString = new SeStringBuilder()
+          .AddItemLink(itemPayload.ItemId, itemPayload.IsHQ)
+          .AddText($": Using default amount {amount}")
+          .Build();
+
+      Svc.Chat.PrintError(seString);
+    }
+    else
+      Svc.Chat.PrintError($"{itemName}: Using default amount {amount}");
+  }
+
     public static void PrintAllRetainersDisabled()
     {
         var seString = new SeStringBuilder()

--- a/Dagobert/Configuration.cs
+++ b/Dagobert/Configuration.cs
@@ -34,6 +34,8 @@ public sealed class Configuration : IPluginConfiguration
 
   public UndercutMode UndercutMode { get; set; } = UndercutMode.FixedAmount;
 
+  public int DefaultAmount { get; set; } = 0;
+
   public int UndercutAmount { get; set; } = 1;
 
   public float MaxUndercutPercentage { get; set; } = 100.0f;

--- a/Dagobert/Windows/ConfigWindow.cs
+++ b/Dagobert/Windows/ConfigWindow.cs
@@ -199,6 +199,25 @@ public sealed class ConfigWindow : Window
       ImGui.EndTooltip();
     }
 
+    int defaultAmount = Plugin.Configuration.DefaultAmount;
+    ImGui.BeginGroup();
+    ImGui.Text("Default amount:");
+    ImGui.SameLine();
+    if (ImGui.InputInt("##defaultAmount", ref defaultAmount))
+    {
+      Plugin.Configuration.DefaultAmount = Math.Clamp(defaultAmount, 0, int.MaxValue);
+      Plugin.Configuration.Save();
+    }
+    ImGui.SameLine();
+    ImGui.Text("Gil");
+    ImGui.EndGroup();
+    if (ImGui.IsItemHovered())
+    {
+      ImGui.BeginTooltip();
+      ImGui.SetTooltip("Default amount in case of error (0 = disabled)");
+      ImGui.EndTooltip();
+    }
+
 
     ImGui.Separator();
 


### PR DESCRIPTION
This feature adds a Default Amount configuration option. If the plugin would normally show the "No price to set" error, it checks the configuration option and uses that amount instead.

<img width="465" height="90" alt="image" src="https://github.com/user-attachments/assets/b5629c9c-b445-4b6a-a615-4f7a6842481a" />
<img width="412" height="69" alt="image" src="https://github.com/user-attachments/assets/b555b12e-c37d-4e19-9eb0-8aa695eb2778" />
