### PR TITLE
Fix HQ price detection when many NQ listings are present

### DIFF
--- a/Dagobert/AutoPinch.cs
+++ b/Dagobert/AutoPinch.cs
@@ -481,6 +481,9 @@ namespace Dagobert
         if (_skipCurrentItem)
           return true;
 
+        if (!_newPrice.HasValue)
+          return false;
+
         // close compare price window
         if (GenericHelpers.TryGetAddonByName<AtkUnitBase>("ItemSearchResult", out var addon))
           addon->Close(true);
@@ -490,7 +493,7 @@ namespace Dagobert
           var ui = &retainerSell->AtkUnitBase;
           var itemName = retainerSell->ItemName->NodeText.ToString();
           _oldPrice = retainerSell->AskingPrice->Value;
-          if (!_newPrice.HasValue || !(_newPrice > 0))
+          if (!(_newPrice > 0))
           {
             if (Plugin.Configuration.DefaultAmount == 0)
             {

--- a/Dagobert/MarketBoardHandler.cs
+++ b/Dagobert/MarketBoardHandler.cs
@@ -53,39 +53,39 @@ namespace Dagobert
       if (!_newRequest)
         return;
 
-      var i = 0;
-      if (_useHq && _items.Single(j => j.RowId == currentOfferings.ItemListings[0].ItemId).CanBeHq)
-      {
-        while (i < currentOfferings.ItemListings.Count && !currentOfferings.ItemListings[i].IsHq)
-          i++;
-      }
-      else
-      {
-        if (currentOfferings.ItemListings.Count > 0)
-          i = 0;
-        else
-          i = currentOfferings.ItemListings.Count;
-      }
-
-      if (i >= currentOfferings.ItemListings.Count || currentOfferings.RequestId == _lastRequestId)
+      if (currentOfferings.ItemListings.Count == 0)
       {
         NewPrice = -1;
-        return; // wait for more incoming offerings (currentOfferings only contains 10 per call)
+        return;
       }
-      else
+
+      var skipNq = _useHq && _items.Single(j => j.RowId == currentOfferings.ItemListings[0].ItemId).CanBeHq;
+      var i = 0;
+      while (i < currentOfferings.ItemListings.Count)
       {
-        int price;
-
-        if (!Plugin.Configuration.UndercutSelf && IsOwnRetainer(currentOfferings.ItemListings[i].RetainerId))
-          price = (int)currentOfferings.ItemListings[i].PricePerUnit;
-        else if (Plugin.Configuration.UndercutMode == UndercutMode.FixedAmount)
-          price = Math.Max((int)currentOfferings.ItemListings[i].PricePerUnit - Plugin.Configuration.UndercutAmount, 1);
+        if (skipNq && !currentOfferings.ItemListings[i].IsHq)
+          i++;
         else
-          price = Math.Max((100 - Plugin.Configuration.UndercutAmount) * (int)currentOfferings.ItemListings[i].PricePerUnit / 100, 1);
-
-        NewPrice = price;
+          break;
       }
 
+      // offerings arrive in batches of 10; if no match in this batch, wait for the next
+      if (i >= currentOfferings.ItemListings.Count)
+        return;
+
+      if (currentOfferings.RequestId == _lastRequestId)
+        return;
+
+      int price;
+
+      if (!Plugin.Configuration.UndercutSelf && IsOwnRetainer(currentOfferings.ItemListings[i].RetainerId))
+        price = (int)currentOfferings.ItemListings[i].PricePerUnit;
+      else if (Plugin.Configuration.UndercutMode == UndercutMode.FixedAmount)
+        price = Math.Max((int)currentOfferings.ItemListings[i].PricePerUnit - Plugin.Configuration.UndercutAmount, 1);
+      else
+        price = Math.Max((100 - Plugin.Configuration.UndercutAmount) * (int)currentOfferings.ItemListings[i].PricePerUnit / 100, 1);
+
+      NewPrice = price;
       _lastRequestId = currentOfferings.RequestId;
       _newRequest = false;
     }


### PR DESCRIPTION
## Summary
- Market board offerings arrive in batches of 10. When searching for HQ listings, the handler was firing `NewPrice=-1` for each batch without a match, causing `SetNewPrice` to run with an invalid price before later batches (containing HQ listings) could arrive.
- `MarketBoardHandler`: when no matching listing is found in a batch, return silently instead of firing `NewPrice=-1`, allowing subsequent batches to be processed. Also guards against empty `ItemListings` and separates the `RequestId` dedup check from the not-found check.
- `AutoPinch.SetNewPrice`: retry while `_newPrice` is null, allowing the TaskManager to wait for later batches to deliver a valid price within the existing 10-second task timeout.

## Test plan
- [x] Auto-pinch HQ items with many NQ listings pushing HQ below the first batch
- [x] Auto-pinch NQ-only items — no regression
- [x] Cancel mid-run and restart — state resets cleanly